### PR TITLE
fixed `require` typo in recurring.js

### DIFF
--- a/models/recurring.js
+++ b/models/recurring.js
@@ -1,5 +1,5 @@
 const validate = require('validate.js');
-const Constraint = require('constraint');
+const Constraint = require('./constraint.js');
 
 const method = Recurring.prototype;
 


### PR DESCRIPTION
Fixed require('./constraint.js') typo in recurring.js